### PR TITLE
Bump org.apache.commons:commons-jexl3 from 3.2.1 to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-jexl3</artifactId>
-            <version>3.2.1</version>
+            <version>3.5.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -6,7 +6,7 @@ module io.descoped.dc.api {
     requires org.slf4j;
     requires io.github.classgraph;
     requires de.huxhorn.sulky.ulid;
-    requires commons.jexl3;
+    requires org.apache.commons.jexl3;
     requires com.fasterxml.jackson.databind;
     requires com.fasterxml.jackson.annotation;
     requires com.fasterxml.jackson.dataformat.yaml;


### PR DESCRIPTION
Bump org.apache.commons:commons-jexl3 from 3.2.1 to 3.5.0 and fix breaking changes